### PR TITLE
Improving error handling and default values.

### DIFF
--- a/includes/class-rapid-products-wc-rest-controller.php
+++ b/includes/class-rapid-products-wc-rest-controller.php
@@ -239,7 +239,7 @@ class Rapid_Products_WC_REST_Controller {
 				'name'    => 'Backorders',
 				'id'      => 'backorders',
 				'type'    => 'select',
-				'value'   => '',
+				'value'   => 'no',
 				'options' => array(
 					array(
 						'id'   => 'no',
@@ -274,7 +274,7 @@ class Rapid_Products_WC_REST_Controller {
 				'name'    => 'Tax Status',
 				'id'      => 'tax_status',
 				'type'    => 'select',
-				'value'   => '',
+				'value'   => 'taxable',
 				'options' => array(
 					array(
 						'id'   => 'taxable',

--- a/src/products/addProductForm.js
+++ b/src/products/addProductForm.js
@@ -70,11 +70,10 @@ export const AddProductForm = (props) => {
 		try {
 			await create(formData);
 			updateMessage('Product Created');
-		} catch (error) {
-			updateMessage(error);
-		} finally {
 			updateChanged(!changed);
 			setFields();
+		} catch (error) {
+			updateMessage(error.message);
 		}
 	};
 

--- a/src/products/image.js
+++ b/src/products/image.js
@@ -20,12 +20,20 @@ export const ImageUpload = (props) => {
 
 	const setImage = async (e) => {
 		const image = e.target.files[0];
+
+		// This checks the file type so only allowed images will be uploaded.
+		const allowed = ['image/jpeg', 'image/png', 'image/gif'];
+		if (!allowed.includes(image.type)) {
+			props.updateMessage('This file type is not allowed');
+			return;
+		}
 		toggleUploading(true);
 		const formData = new window.FormData();
 		formData.append('file', image);
 		formData.append('title', image.name);
 		formData.append('type', image.type);
 		try {
+			props.updateMessage('');
 			const resp = await addImage(formData);
 			props.setImageID(resp.id);
 			setSelectedImage(URL.createObjectURL(image));


### PR DESCRIPTION
It was possible to upload any file type accepted by WordPress without error.  This PR adds a check for the file type before uploading.  Currently, JPG, PNG, and GIF images are allowed.  A possible future enhancement would be to load the image types allowed by WordPress so this reflects any modifications on a site such as allowing SVG images.

This also adds default values to any fields using select elements.  Without a default value, creating a second product without changing the select field would produce an error.  This allows additional products to be created without triggering an error.

This PR also fixes some error handling issues.  Instead of triggering a white screen, an error returned by the API will add the error message to the screen.  Also, uploading a new image will clear any error messages.  Previously, an error message about an image would remain even after another image was successfully loaded.  Now the message is cleared when an acceptable image is added to the uploader.


